### PR TITLE
Fix logo link URL to point to project repository

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -48,7 +48,7 @@ class Main extends AbstractApplication {
 
     createBrandTag() {
       let a = document.createElement("a");
-      a.href = "http://github.com/pistolshrimpgames/";
+      a.href = "https://github.com/pistolshrimpgames/ProceduralPlanet";
       a.innerHTML = "<div id='brandTag'><img id='brandTagImage' src='assets/textures/pistolshrimp_logoonly.png'>UQM Planet Generator</div>";
       document.body.appendChild(a);
     }


### PR DESCRIPTION
Suggestion going forward: point the logo to the tool itself (https://pistolshrimpgames.com/planets/), and have a separate GitHub repo link somewhere else on the page. 🙂 