### PR TITLE
Hide UI controls when pressing `h` only if there's no focus on any element

### DIFF
--- a/src/js/views/AbstractApplication.js
+++ b/src/js/views/AbstractApplication.js
@@ -107,6 +107,10 @@ class AbstractApplication {
     }
 
     onKeyDown(e) {
+      if (e.target.nodeName != 'BODY') {
+        return;
+      }
+
       if (e.keyCode == '72')
   		{
   			var brandTag = document.getElementById("brandTag");


### PR DESCRIPTION
Fixes #3. This allows using "h" e.g. in the inputs without triggering the hiding of UI controls.