### PR TITLE
Fix relative paths for TTF font loading in Webpack

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -71,13 +71,14 @@ module.exports = {
             {
                 test: /\.ttf$/,
                 use: [
-                  {
-                    loader: 'ttf-loader',
-                    options: {
-                      name: './fonts/[hash].[ext]',
+                    {
+                        loader: "file-loader",
+                        options: {
+                            name: "[name].[ext]",
+                            outputPath: "assets/fonts/",
+                        },
                     },
-                  },
-               ]
+                ]
             },
             { test: /\.(glsl|frag|vert)$/, loader: 'raw-loader', exclude: /node_modules/ },
             { test: /\.(glsl|frag|vert)$/, loader: 'glslify-loader', exclude: /node_modules/ },

--- a/config/index.js
+++ b/config/index.js
@@ -4,10 +4,10 @@ var path = require('path')
 module.exports = {
     build: {
         env: require('./prod.env'),
-        index: path.resolve(__dirname, '../dist/index.html'),
-        assetsRoot: path.resolve(__dirname, '../dist'),
+        index: path.resolve(__dirname, '../dist/planets/index.html'),
+        assetsRoot: path.resolve(__dirname, '../dist/planets'),
         assetsSubDirectory: 'static',
-        assetsPublicPath: '/',
+        assetsPublicPath: '/planets/',
         productionSourceMap: true,
         // Gzip off by default as many popular static hosts such as
         // Surge or Netlify already gzip all static assets for you.

--- a/index.html
+++ b/index.html
@@ -19,19 +19,19 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 
         <!-- Favicon  -->
-        <link rel="apple-touch-icon" sizes="57x57" href="./src/assets/img/ico/apple-icon-57x57.png">
-        <link rel="apple-touch-icon" sizes="60x60" href="./src/assets/img/ico/apple-icon-60x60.png">
-        <link rel="apple-touch-icon" sizes="72x72" href="./src/assets/img/ico/apple-icon-72x72.png">
-        <link rel="apple-touch-icon" sizes="76x76" href="./src/assets/img/ico/apple-icon-76x76.png">
-        <link rel="apple-touch-icon" sizes="114x114" href="./src/assets/img/ico/apple-icon-114x114.png">
-        <link rel="apple-touch-icon" sizes="120x120" href="./src/assets/img/ico/apple-icon-120x120.png">
-        <link rel="apple-touch-icon" sizes="144x144" href="./src/assets/img/ico/apple-icon-144x144.png">
-        <link rel="apple-touch-icon" sizes="152x152" href="./src/assets/img/ico/apple-icon-152x152.png">
-        <link rel="apple-touch-icon" sizes="180x180" href="./src/assets/img/ico/apple-icon-180x180.png">
-        <link rel="icon" type="image/png" sizes="192x192"  href="./src/assets/img/ico/android-icon-192x192.png">
-        <link rel="icon" type="image/png" sizes="32x32" href="./src/assets/img/ico/favicon-32x32.png">
-        <link rel="icon" type="image/png" sizes="96x96" href="./src/assets/img/ico/favicon-96x96.png">
-        <link rel="icon" type="image/png" sizes="16x16" href="./src/assets/img/ico/favicon-16x16.png">
+        <link rel="apple-touch-icon" sizes="57x57" href="./assets/img/ico/apple-icon-57x57.png">
+        <link rel="apple-touch-icon" sizes="60x60" href="./assets/img/ico/apple-icon-60x60.png">
+        <link rel="apple-touch-icon" sizes="72x72" href="./assets/img/ico/apple-icon-72x72.png">
+        <link rel="apple-touch-icon" sizes="76x76" href="./assets/img/ico/apple-icon-76x76.png">
+        <link rel="apple-touch-icon" sizes="114x114" href="./assets/img/ico/apple-icon-114x114.png">
+        <link rel="apple-touch-icon" sizes="120x120" href="./assets/img/ico/apple-icon-120x120.png">
+        <link rel="apple-touch-icon" sizes="144x144" href="./assets/img/ico/apple-icon-144x144.png">
+        <link rel="apple-touch-icon" sizes="152x152" href="./assets/img/ico/apple-icon-152x152.png">
+        <link rel="apple-touch-icon" sizes="180x180" href="./assets/img/ico/apple-icon-180x180.png">
+        <link rel="icon" type="image/png" sizes="192x192"  href="./assets/img/ico/android-icon-192x192.png">
+        <link rel="icon" type="image/png" sizes="32x32" href="./assets/img/ico/favicon-32x32.png">
+        <link rel="icon" type="image/png" sizes="96x96" href="./assets/img/ico/favicon-96x96.png">
+        <link rel="icon" type="image/png" sizes="16x16" href="./assets/img/ico/favicon-16x16.png">
         <meta name="msapplication-TileColor" content="#000000">
         <meta name="msapplication-TileImage" content="./src/assets/img/ico/ms-icon-144x144.png">
         <meta name="theme-color" content="#000000">

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,16 +1,16 @@
 @font-face {
   font-family: "UQM-3DO";
-  src: url('/assets/fonts/UQM-3DOMenuLabels.ttf') format('truetype');
+  src: url('../fonts/UQM-3DOMenuLabels.ttf') format('truetype');
 }
 
 @font-face {
   font-family: "UQM-CommanderFont";
-  src: url('/assets/fonts/UQM-CommanderFont.ttf') format('truetype');
+  src: url('../fonts/UQM-CommanderFont.ttf') format('truetype');
 }
 
 @font-face {
   font-family: "UQM-TinyFont";
-  src: url('/assets/fonts/UQM-TinyFont.ttf') format('truetype');
+  src: url('../fonts/UQM-TinyFont.ttf') format('truetype');
 }
 
 body {


### PR DESCRIPTION
Fixes #14. I tried various things, and this combo was the one that worked best for me. A few things to note:

- The `planets/` path from which the tool is served in production is now present in the config. If the path changes, the config needs to change as well. Dev mode still uses root.
- The production build now creates the files in `dist/planets/` instead of `dist/`.
- Dropping `ttf-loader` (probably) means that the fonts can't be used directly in JavaScript (see [usage examples](https://github.com/unimonkiez/ttf-loader#usage)), but that's likely not going to be an issue. 🙂 
- I didn't remove `ttf-loader` from package.json, since it would've resulted in a big chunk of unrelated changes in package-lock.json due to Node/NPM version differences.

Tested in dev and production modes with Chrome.

If there are still some issues with the font file serving in production, please let me know.