### PR TITLE
Add custom code for jewel-type planets (Emerald, Ruby, Sapphire)

### DIFF
--- a/src/js/shaders/flowNoiseMap.frag
+++ b/src/js/shaders/flowNoiseMap.frag
@@ -9,6 +9,7 @@ uniform float res2;
 uniform float resMix;
 uniform float mixScale;
 uniform float doesRidged;
+uniform bool isJewel;
 const int octaves = 16;
 
 // #define M_PI 3.1415926535897932384626433832795;
@@ -55,6 +56,15 @@ float baseNoise(vec3 pos, float frq, float seed ) {
 	// increase contrast
 	n = ( (n - 0.5) * 2.0 ) + 0.5;
 
+	return n;
+}
+
+float jewelNoise(vec3 pos, float seed ) {
+	// There's no deep logic behind this, it's just created with trial and error based on the other noise functions to
+	// achieve bigger, sharper lines and areas instead of a "watercolory" map
+	float n = noise(3.0 * vec3(pos + seed));
+	n = (n + 1.0) * 0.5;
+	n = 2.0 * (0.5 - abs(0.5 - n));
 	return n;
 }
 
@@ -129,6 +139,16 @@ void main() {
 	vec3 sphericalCoord = getSphericalCoord(index, x*resolution, y*resolution, resolution);
 
 	float sub1, sub2, sub3, n;
+
+	if (isJewel) {
+		sub1 = jewelNoise(sphericalCoord, seed + 16.432);
+		sub2 = jewelNoise(sphericalCoord, seed + 47.991);
+		n = jewelNoise(sphericalCoord + vec3((sub1 / sub2) * 0.1), seed + 20.187);
+
+		gl_FragColor = vec4(vec3(n), 1.0);
+
+		return;
+	}
 
 	float resMod = 1.0; // overall res magnification
 	float resMod2 = mixScale; // minimum res mod

--- a/src/js/uqmPlanetData.json
+++ b/src/js/uqmPlanetData.json
@@ -36,6 +36,10 @@
     "seeds": [ "Oke Olca Orehi" ]
   },
   {
+    "type": "Emerald",
+    "seeds": [ "Ternajil Evi Civz", "Ze Tikepoj Ovf", "Usaluor Tik", "Fimje Tehsul" ]
+  },
+  {
     "type": "Fluorescent",
     "seeds": [ "Ufp Ad Pov", "Lek Lepko", "Nikco Goejan", "Oju", "Sobilb Itz" ]
   },
@@ -88,8 +92,12 @@
     "seeds": [ "Jiwfoge Wekvic Ucuu", "Efzek Opemi", "Vasajlo Hulefhik", "Zop Utbugmi Wifcigik", "Vura" ]
   },
   {
+    "type": "Ruby",
+    "seeds": [ "Fihivo Ceroff", "Hid Coap", "Tiwjafiz", "Cewmupmi Hon" ]
+  },
+  {
     "type": "Sapphire",
-    "seeds": [ "Juototis Jevoviz" ]
+    "seeds": [ "Honhoju Cileliwt Kun", "Veggupi Tucjaom", "Pejigr Vomdin Romaf", "Razt Herec Ari" ]
   },
   {
     "type": "Treasure",

--- a/src/js/views/Atmosphere.js
+++ b/src/js/views/Atmosphere.js
@@ -4,7 +4,7 @@ import shaderFrag from 'shaders/atmos.frag'
 
 class Atmosphere {
 
-  constructor() {
+  constructor(props) {
     this.view = new THREE.Object3D();
 
     this.time = 0.0;
@@ -21,8 +21,17 @@ class Atmosphere {
     // this.atmo4 = 0.46;
     // this.atmo5 = 0.36;
 
-    // this.randomizeColor();
     this.color = new THREE.Color(0x00ffff);
+    this.uqmPlanetType = props.uqmPlanetType;
+
+    if (this.uqmPlanetType === 'Emerald') {
+      this.color = new THREE.Color(0x00dc00);
+    } else if (this.uqmPlanetType === 'Ruby') {
+      this.color = new THREE.Color(0xdc0000);
+    } else if (this.uqmPlanetType === 'Sapphire') {
+      this.color = new THREE.Color(0x0000dc);
+    }
+
     this.size = 1002;
     this.atmosphere = 0.3;
     // window.gui.add(this, "atmosphere", 0.0, 1.0).step(0.01);

--- a/src/js/views/Biome.js
+++ b/src/js/views/Biome.js
@@ -23,10 +23,26 @@ class Biome {
   generateTexture(props) {
 
     this.waterLevel = props.waterLevel;
+    this.uqmPlanetType = props.uqmPlanetType;
 
     let h = this.randRange(0.0, 1.0);
     let s = this.randRange(0.0, 0.7);
     let l = this.randRange(0.0, 0.6);
+
+    if (this.uqmPlanetType === 'Emerald') {
+      h = 0.38;
+      s = 0.37;
+      l = 0.28;
+    } else if (this.uqmPlanetType === 'Ruby') {
+      h = 0.97;
+      s = 0.87;
+      l = 0.42;
+    } else if (this.uqmPlanetType === 'Sapphire') {
+      h = 0.69;
+      s = 0.91;
+      l = 0.41;
+    }
+
     this.baseColor = new THREE.Color().setHSL(h, s, l);
     this.colorAngle = this.randRange(0.2, 0.4)
     this.satRange = this.randRange(0.3, 0.5);
@@ -37,18 +53,19 @@ class Biome {
 
     this.drawBase();
 
-    // circles
-    let numCircles = Math.round(this.randRange(50, 100));
-    numCircles = 100;
-    for (let i=0; i<numCircles; i++) {
-      this.randomGradientCircle();
+    if (!this.isJewelPlanet(this.uqmPlanetType)) {
+      // circles
+      let numCircles = Math.round(this.randRange(50, 100));
+      numCircles = 100;
+      for (let i=0; i<numCircles; i++) {
+        this.randomGradientCircle();
+      }
+
+      this.drawDetail();
+      this.drawInland();
+      this.drawBeach();
+      this.drawWater();
     }
-
-    this.drawDetail();
-    this.drawInland();
-    this.drawBeach();
-    this.drawWater();
-
 
     this.texture = new THREE.CanvasTexture(this.canvas);
   }
@@ -66,10 +83,14 @@ class Biome {
 
     for (let i=0; i<5; i++) {
       let x = 0;
-      let y =0;
+      let y = 0;
       let width = this.width;
       let height = this.height;
-      this.randomGradientRect(x, y, width, height);
+      if (this.isJewelPlanet(this.uqmPlanetType)) {
+        this.randomJewelStrip(this.uqmPlanetType, x, y, width, height);
+      } else {
+        this.randomGradientRect(x, y, width, height);
+      }
     }
   }
 
@@ -138,6 +159,23 @@ class Biome {
     let gradient = this.ctx.createLinearGradient(x1, y1, x2, y2);
 
     let c = this.randomColor();
+    gradient.addColorStop(this.randRange(0, 0.5), "rgba("+c.r+", "+c.g+", "+c.b+", 0.0)");
+    gradient.addColorStop(0.5, "rgba("+c.r+", "+c.g+", "+c.b+", 0.8)");
+    gradient.addColorStop(this.randRange(0.5, 1.0), "rgba("+c.r+", "+c.g+", "+c.b+", 0.0)");
+
+    this.ctx.fillStyle = gradient;
+    this.ctx.fillRect(x, y, width, height);
+  }
+
+  randomJewelStrip(uqmPlanetType, x, y, width, height) {
+    let x1 = this.randRange(0, this.width);
+    let y1 = this.randRange(0, this.height);
+    let x2 = this.randRange(0, this.width);
+    let y2 = this.randRange(0, this.height);
+
+    let gradient = this.ctx.createLinearGradient(x1, y1, x2, y2);
+
+    let c = this.randomJewelColor(uqmPlanetType);
     gradient.addColorStop(this.randRange(0, 0.5), "rgba("+c.r+", "+c.g+", "+c.b+", 0.0)");
     gradient.addColorStop(0.5, "rgba("+c.r+", "+c.g+", "+c.b+", 0.8)");
     gradient.addColorStop(this.randRange(0.5, 1.0), "rgba("+c.r+", "+c.g+", "+c.b+", 0.0)");
@@ -301,6 +339,34 @@ class Biome {
             b: Math.round(newColor.b*255)};
   }
 
+  randomJewelColor(uqmPlanetType) {
+    let newColor = this.baseColor.clone();
+    let hue = this.randRange(0.0, 1.0);
+    let saturation =  this.randRange(0.0, 1.0);
+
+    if (uqmPlanetType === 'Emerald') {
+      hue = 0.38;
+      saturation = this.randRange(0.2, 0.4);
+    } else if (uqmPlanetType === 'Ruby') {
+      hue = 0.97;
+      saturation = this.randRange(0.7, 0.9);
+    } else if (uqmPlanetType === 'Sapphire') {
+      hue = 0.69;
+      saturation = this.randRange(0.7, 0.9);
+    }
+
+    // Mostly dark colors, but some lighter ones for effect
+    let lightness = window.rng() < 0.9 ? this.randRange(0.05, 0.15) : this.randRange(0.45, 0.55);
+
+    newColor.setHSL(hue, saturation, lightness);
+
+    return {
+      r: Math.round(newColor.r * 255),
+      g: Math.round(newColor.g * 255),
+      b: Math.round(newColor.b * 255)
+    };
+  }
+
   randomColor() {
 
     let newColor = this.baseColor.clone();
@@ -383,6 +449,11 @@ class Biome {
     let dist = v2 - v1;
     return v1 + (dist * amount);
   }
+
+  isJewelPlanet(uqmPlanetType) {
+    return uqmPlanetType === 'Emerald' || uqmPlanetType === 'Ruby' || uqmPlanetType === 'Sapphire';
+  }
+
 
 }
 

--- a/src/js/views/NoiseMap.js
+++ b/src/js/views/NoiseMap.js
@@ -24,7 +24,8 @@ class NoiseMap extends Map {
           res2: {type: "f", value: 0},
           resMix: {type: "f", value: 0},
           mixScale: {type: "f", value: 0},
-          doesRidged: {type: "f", value: 0}
+          doesRidged: {type: "f", value: 0},
+          isJewel: {type: "b", value: false}
         },
         vertexShader: vertShader,
         fragmentShader: fragShader,
@@ -41,6 +42,7 @@ class NoiseMap extends Map {
     // props.res2
     // props.resMix
     // props.mixScale
+    // props.isJewel
 
     let resolution = props.resolution;
 
@@ -52,6 +54,7 @@ class NoiseMap extends Map {
       this.mats[i].uniforms.resMix.value = props.resMix;
       this.mats[i].uniforms.mixScale.value = props.mixScale;
       this.mats[i].uniforms.doesRidged.value = props.doesRidged;
+      this.mats[i].uniforms.isJewel.value = props.isJewel;
       this.mats[i].needsUpdate = true;
     }
 

--- a/src/js/views/Planet.js
+++ b/src/js/views/Planet.js
@@ -424,7 +424,7 @@ class Planet {
     this.updatePlanetName();
 
     this.seed = this.randRange(0, 1) * 1000.0;
-    this.waterLevel = this.randRange(0.1, 0.5);
+    this.waterLevel = this.isJewelPlanet(this.uqmPlanetType) ? 0.0 : this.randRange(0.1, 0.5);
     // this.clouds.resolution = this.resolution;
 
     this.updateNormalScaleForRes(this.resolution);
@@ -433,7 +433,11 @@ class Planet {
 
     this.stars.resolution = this.resolution;
     this.nebula.resolution = this.resolution;
-    this.atmosphere.randomizeColor();
+
+    if (!this.isJewelPlanet(this.uqmPlanetType)) {
+      this.atmosphere.randomizeColor();
+    }
+
     // this.clouds.randomizeColor();
     // this.clouds.color = this.atmosphere.color;
 
@@ -449,8 +453,8 @@ class Planet {
       res2: this.randRange(resMin, resMax),
       resMix: this.randRange(resMin, resMax),
       mixScale: this.randRange(0.5, 1.0),
-      doesRidged: Math.floor(this.randRange(0, 4))
-      // doesRidged: 1
+      doesRidged: Math.floor(this.randRange(0, 4)),
+      isJewel: this.isJewelPlanet(this.uqmPlanetType)
     });
 
     let resMod = this.randRange(3, 10);
@@ -464,8 +468,8 @@ class Planet {
       res2: this.randRange(resMin, resMax),
       resMix: this.randRange(resMin, resMax),
       mixScale: this.randRange(0.5, 1.0),
-      doesRidged: Math.floor(this.randRange(0, 4))
-      // doesRidged: 0
+      doesRidged: Math.floor(this.randRange(0, 4)),
+      isJewel: false
     });
 
     this.textureMap.render({
@@ -501,7 +505,6 @@ class Planet {
     });
 
     this.sun.render();
-
 
     window.renderQueue.addCallback(() => {
       this.updateMaterial();
@@ -547,7 +550,10 @@ class Planet {
   }
 
   renderBiomeTexture() {
-    this.biome.generateTexture({waterLevel: this.waterLevel});
+    this.biome.generateTexture({
+      waterLevel: this.waterLevel,
+      uqmPlanetType: this.uqmPlanetType
+    });
   }
 
   renderNebulaeGradient() {
@@ -555,7 +561,9 @@ class Planet {
   }
 
   createAtmosphere() {
-    this.atmosphere = new Atmosphere();
+    this.atmosphere = new Atmosphere({
+      uqmPlanetType: this.uqmPlanetType
+    });
     // this.atmosphere.color = this.glow.color;
     this.view.add(this.atmosphere.view);
   }
@@ -658,7 +666,11 @@ class Planet {
     if (!results) return null;
     if (!results[2]) return '';
     return decodeURIComponent(results[2].replace(/\+/g, " "));
-}
+  }
+
+  isJewelPlanet(uqmPlanetType) {
+    return uqmPlanetType === 'Emerald' || uqmPlanetType === 'Ruby' || uqmPlanetType === 'Sapphire';
+  }
 
 }
 


### PR DESCRIPTION
Related to https://github.com/pistolshrimpgames/ProceduralPlanet/issues/11.

This PR adds some customizations for jewel-type planets (Emerald, Ruby, and Sapphire Worlds):

- Enforced base colors for the planet and atmosphere (the atmosphere color is probably not that significant though).
- No inland, beaches, water etc.
- A custom shader configuration for the height map to give a surface with bigger, sharper lines and areas than the default one. The moisture map still uses the default shader configs and thereby provides some mushyness to the surface.

All changes should be backwards-compatible, so previously generated seeds should yield the same planets as before.

Emerald:

![emerald](https://github.com/pistolshrimpgames/ProceduralPlanet/assets/1522694/461efbc8-30e9-4108-8086-e66f5041cfc8)

Ruby:

![ruby](https://github.com/pistolshrimpgames/ProceduralPlanet/assets/1522694/fed5a08d-f708-42b8-9283-309da1952b16)

Sapphire:

![sapphire](https://github.com/pistolshrimpgames/ProceduralPlanet/assets/1522694/4441d433-f03a-4efc-aac4-2d26db9faf85)

Changing the lighting gives the planets a jewely glow:

![emerald-glow](https://github.com/pistolshrimpgames/ProceduralPlanet/assets/1522694/791f5462-1c2a-4436-b722-b969fe71f849)

These planets don't have quite the marble look that the concept art has, but it's a step towards something like it. Perhaps someone else (or future me) can come up with a better fragment shader configuration. Additional planet details could help too.