### PR TITLE
Add Actions pipeline to deploy production artifacts to GitHub Pages, fix relative paths for TTF font loading in Webpack

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -1,0 +1,54 @@
+name: Build production version and deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["master"]
+
+  # Allow to be manually started from the Actions tab
+  workflow_dispatch:
+  
+# Allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+  
+# Allow only one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+  
+jobs:
+  build-and-deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⬅️ Checkout
+        uses: actions/checkout@v3
+      
+      - name: 🖥 Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: "npm"
+      
+      - name: 🛠️ Build
+        run: npm install && npm run build
+
+      - name: 📄 Setup GitHub Pages
+        uses: actions/configure-pages@v3
+
+      - name: ✍️ Set outputs
+        id: custom_outputs
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        
+      - name: 📦 Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: "${{github.workspace}}/dist"
+    
+      - name: 🚀 Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -71,13 +71,14 @@ module.exports = {
             {
                 test: /\.ttf$/,
                 use: [
-                  {
-                    loader: 'ttf-loader',
-                    options: {
-                      name: './fonts/[hash].[ext]',
+                    {
+                        loader: "file-loader",
+                        options: {
+                            name: "[name].[ext]",
+                            outputPath: "assets/fonts/",
+                        },
                     },
-                  },
-               ]
+                ]
             },
             { test: /\.(glsl|frag|vert)$/, loader: 'raw-loader', exclude: /node_modules/ },
             { test: /\.(glsl|frag|vert)$/, loader: 'glslify-loader', exclude: /node_modules/ },

--- a/config/index.js
+++ b/config/index.js
@@ -4,10 +4,10 @@ var path = require('path')
 module.exports = {
     build: {
         env: require('./prod.env'),
-        index: path.resolve(__dirname, '../dist/index.html'),
-        assetsRoot: path.resolve(__dirname, '../dist'),
+        index: path.resolve(__dirname, '../dist/planets/index.html'),
+        assetsRoot: path.resolve(__dirname, '../dist/planets'),
         assetsSubDirectory: 'static',
-        assetsPublicPath: '/',
+        assetsPublicPath: '/planets/',
         productionSourceMap: true,
         // Gzip off by default as many popular static hosts such as
         // Surge or Netlify already gzip all static assets for you.

--- a/config/index.js
+++ b/config/index.js
@@ -4,10 +4,10 @@ var path = require('path')
 module.exports = {
     build: {
         env: require('./prod.env'),
-        index: path.resolve(__dirname, '../dist/planets/index.html'),
-        assetsRoot: path.resolve(__dirname, '../dist/planets'),
+        index: path.resolve(__dirname, '../dist/index.html'),
+        assetsRoot: path.resolve(__dirname, '../dist'),
         assetsSubDirectory: 'static',
-        assetsPublicPath: '/planets/',
+        assetsPublicPath: '/ProceduralPlanet/', // This matches the repository name, with the files deployed to pistolshrimpgames.github.io/ProceduralPlanet/
         productionSourceMap: true,
         // Gzip off by default as many popular static hosts such as
         // Surge or Netlify already gzip all static assets for you.

--- a/index.html
+++ b/index.html
@@ -19,19 +19,19 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 
         <!-- Favicon  -->
-        <link rel="apple-touch-icon" sizes="57x57" href="./src/assets/img/ico/apple-icon-57x57.png">
-        <link rel="apple-touch-icon" sizes="60x60" href="./src/assets/img/ico/apple-icon-60x60.png">
-        <link rel="apple-touch-icon" sizes="72x72" href="./src/assets/img/ico/apple-icon-72x72.png">
-        <link rel="apple-touch-icon" sizes="76x76" href="./src/assets/img/ico/apple-icon-76x76.png">
-        <link rel="apple-touch-icon" sizes="114x114" href="./src/assets/img/ico/apple-icon-114x114.png">
-        <link rel="apple-touch-icon" sizes="120x120" href="./src/assets/img/ico/apple-icon-120x120.png">
-        <link rel="apple-touch-icon" sizes="144x144" href="./src/assets/img/ico/apple-icon-144x144.png">
-        <link rel="apple-touch-icon" sizes="152x152" href="./src/assets/img/ico/apple-icon-152x152.png">
-        <link rel="apple-touch-icon" sizes="180x180" href="./src/assets/img/ico/apple-icon-180x180.png">
-        <link rel="icon" type="image/png" sizes="192x192"  href="./src/assets/img/ico/android-icon-192x192.png">
-        <link rel="icon" type="image/png" sizes="32x32" href="./src/assets/img/ico/favicon-32x32.png">
-        <link rel="icon" type="image/png" sizes="96x96" href="./src/assets/img/ico/favicon-96x96.png">
-        <link rel="icon" type="image/png" sizes="16x16" href="./src/assets/img/ico/favicon-16x16.png">
+        <link rel="apple-touch-icon" sizes="57x57" href="./assets/img/ico/apple-icon-57x57.png">
+        <link rel="apple-touch-icon" sizes="60x60" href="./assets/img/ico/apple-icon-60x60.png">
+        <link rel="apple-touch-icon" sizes="72x72" href="./assets/img/ico/apple-icon-72x72.png">
+        <link rel="apple-touch-icon" sizes="76x76" href="./assets/img/ico/apple-icon-76x76.png">
+        <link rel="apple-touch-icon" sizes="114x114" href="./assets/img/ico/apple-icon-114x114.png">
+        <link rel="apple-touch-icon" sizes="120x120" href="./assets/img/ico/apple-icon-120x120.png">
+        <link rel="apple-touch-icon" sizes="144x144" href="./assets/img/ico/apple-icon-144x144.png">
+        <link rel="apple-touch-icon" sizes="152x152" href="./assets/img/ico/apple-icon-152x152.png">
+        <link rel="apple-touch-icon" sizes="180x180" href="./assets/img/ico/apple-icon-180x180.png">
+        <link rel="icon" type="image/png" sizes="192x192"  href="./assets/img/ico/android-icon-192x192.png">
+        <link rel="icon" type="image/png" sizes="32x32" href="./assets/img/ico/favicon-32x32.png">
+        <link rel="icon" type="image/png" sizes="96x96" href="./assets/img/ico/favicon-96x96.png">
+        <link rel="icon" type="image/png" sizes="16x16" href="./assets/img/ico/favicon-16x16.png">
         <meta name="msapplication-TileColor" content="#000000">
         <meta name="msapplication-TileImage" content="./src/assets/img/ico/ms-icon-144x144.png">
         <meta name="theme-color" content="#000000">

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,16 +1,16 @@
 @font-face {
   font-family: "UQM-3DO";
-  src: url('/assets/fonts/UQM-3DOMenuLabels.ttf') format('truetype');
+  src: url('../fonts/UQM-3DOMenuLabels.ttf') format('truetype');
 }
 
 @font-face {
   font-family: "UQM-CommanderFont";
-  src: url('/assets/fonts/UQM-CommanderFont.ttf') format('truetype');
+  src: url('../fonts/UQM-CommanderFont.ttf') format('truetype');
 }
 
 @font-face {
   font-family: "UQM-TinyFont";
-  src: url('/assets/fonts/UQM-TinyFont.ttf') format('truetype');
+  src: url('../fonts/UQM-TinyFont.ttf') format('truetype');
 }
 
 body {


### PR DESCRIPTION
This PR enables automatic deployment of the static Planet Generator files to GitHub Pages upon merge to master branch, with the URL being https://pistolshrimpgames.github.io/ProceduralPlanet/. The deployed files shouldn't mess with the Pistol Shrimp documentation site at https://pistolshrimpgames.github.io/, as long as no-one adds a directory named `ProceduralPlanet` to the documentation site. 🙂 

Before merging this PR, please go to the [repository settings > Pages](https://github.com/pistolshrimpgames/ProceduralPlanet/settings/pages) and switch the source from `Deploy from a branch` to `GitHub Actions`.

![github-pages](https://github.com/pistolshrimpgames/ProceduralPlanet/assets/1522694/367c9252-2899-4bf7-bc74-cc63d82d2f5c)

Dry-run (will delete after merge):
- Planet Generator: https://crocodele.github.io/ProceduralPlanet/
- Dummy documentation site: https://crocodele.github.io/

I included the changes from https://github.com/pistolshrimpgames/ProceduralPlanet/pull/15 in this PR, since both are touching the Webpack build config.