### PR TITLE
Render performance

### DIFF
--- a/src/js/views/Map.js
+++ b/src/js/views/Map.js
@@ -15,8 +15,7 @@ class Map {
 
     for (let i = 0; i < 6; i++) {
       this.renderTargets[i] = new THREE.WebGLRenderTarget(1, 1, {minFilter: THREE.LinearFilter, magFilter: THREE.NearestFilter, format: THREE.RGBAFormat});
-  		this.maps[i] = this.renderTargets[i].texture;
-      //this.maps.push(new THREE.Texture());
+      this.maps[i] = this.renderTargets[i].texture;
     }
   }
 
@@ -32,13 +31,11 @@ class Map {
       let scene = new THREE.Scene();
       scene.add(plane);
 
-      //window.renderer.compile(scene, this.textureCamera);
       for (let i = 0; i < 6; i++) {
         this.renderTargets[i].setSize(res, res);
         plane.material = this.mats[i];
         window.renderer.setRenderTarget(this.renderTargets[i]);
-
-    		window.renderer.render(scene, this.camera);
+        window.renderer.render(scene, this.camera);
       }
 
       window.renderer.setRenderTarget(null);

--- a/src/js/views/Map.js
+++ b/src/js/views/Map.js
@@ -7,52 +7,52 @@ class Map {
   }
 
   setup() {
+    this.camera = new THREE.OrthographicCamera(-1, 1, 1, -1, -100, 100);    
+    this.camera.position.z = 10;
+
     this.maps = [];
-    this.textures = [];
-    this.textureCameras = [];
-    this.textureScenes = [];
-    this.planes = [];
-    this.geos = [];
+    this.renderTargets = [];
 
     for (let i = 0; i < 6; i++) {
-      let tempRes = 1000;
-      this.textures[i] = new THREE.WebGLRenderTarget(tempRes, tempRes, {minFilter: THREE.LinearFilter, magFilter: THREE.NearestFilter, format: THREE.RGBAFormat});
-  		this.textureCameras[i] = new THREE.OrthographicCamera(-tempRes/2, tempRes/2, tempRes/2, -tempRes/2, -100, 100);
-  		this.textureCameras[i].position.z = 10;
-
-  		this.textureScenes[i] = new THREE.Scene();
-      this.geos[i] = new THREE.PlaneGeometry(1, 1);
-  		this.planes[i] = new THREE.Mesh(this.geos[i], this.mats[i]);
-  		this.planes[i].position.z = -10;
-  		this.textureScenes[i].add(this.planes[i]);
-  		// window.renderer.render(textureScene, textureCamera, texture, true);
-  		this.maps.push(this.textures[i].texture);
+      this.renderTargets[i] = new THREE.WebGLRenderTarget(1, 1, {minFilter: THREE.LinearFilter, magFilter: THREE.NearestFilter, format: THREE.RGBAFormat});
+  		this.maps[i] = this.renderTargets[i].texture;
+      //this.maps.push(new THREE.Texture());
     }
   }
 
   render(props) {
-    let resolution = props.resolution;
+    let res = props.resolution;
 
-    for (let i = 0; i < 6; i++) {
+    this.camera.left = -res/2;
+    this.camera.right = res/2;
+    this.camera.top = res/2;
+    this.camera.bottom = -res/2;
+    this.camera.updateProjectionMatrix();
 
-      window.renderQueue.addAction(() => {
-        this.textures[i].setSize(resolution, resolution);
-        this.textures[i].needsUpdate = true;
-        this.textureCameras[i].left = -resolution/2;
-        this.textureCameras[i].right = resolution/2;
-        this.textureCameras[i].top = resolution/2;
-        this.textureCameras[i].bottom = -resolution/2;
-        this.textureCameras[i].updateProjectionMatrix();
-        this.geos[i] = new THREE.PlaneGeometry(resolution, resolution);
-        this.planes[i].geometry = this.geos[i];
-        window.renderer.setRenderTarget(this.textures[i]);
-    		window.renderer.render(this.textureScenes[i], this.textureCameras[i]);
-        window.renderer.setRenderTarget(null);
-        this.geos[i].dispose();
 
-      });
+    window.renderQueue.addAction(() => {
 
-    }
+      let geo = new THREE.PlaneGeometry(res, res);
+      let plane = new THREE.Mesh(geo);
+      plane.position.z = -10;
+
+      let scene = new THREE.Scene();
+      scene.add(plane);
+
+      //window.renderer.compile(scene, this.textureCamera);
+      for (let i = 0; i < 6; i++) {
+        this.renderTargets[i].setSize(res, res);
+        plane.material = this.mats[i];
+        window.renderer.setRenderTarget(this.renderTargets[i]);
+
+    		window.renderer.render(scene, this.camera);
+      }
+
+      window.renderer.setRenderTarget(null);
+      geo.dispose();
+
+    });
+
   }
 
 }

--- a/src/js/views/Map.js
+++ b/src/js/views/Map.js
@@ -7,7 +7,7 @@ class Map {
   }
 
   setup() {
-    this.camera = new THREE.OrthographicCamera(-1, 1, 1, -1, -100, 100);    
+    this.camera = new THREE.OrthographicCamera(-1, 1, 1, -1, -100, 100);
     this.camera.position.z = 10;
 
     this.maps = [];
@@ -23,16 +23,9 @@ class Map {
   render(props) {
     let res = props.resolution;
 
-    this.camera.left = -res/2;
-    this.camera.right = res/2;
-    this.camera.top = res/2;
-    this.camera.bottom = -res/2;
-    this.camera.updateProjectionMatrix();
-
-
     window.renderQueue.addAction(() => {
 
-      let geo = new THREE.PlaneGeometry(res, res);
+      let geo = new THREE.PlaneGeometry(2, 2);
       let plane = new THREE.Mesh(geo);
       plane.position.z = -10;
 


### PR DESCRIPTION
Re-uses single scene, camera, mesh, and geometry for all six renders for a given map refresh.

Camera and mesh do not need to be re-adjusted for different resolutions, this was unnecessary.

I think I can do more, but this is a pretty good improvement already.